### PR TITLE
Crash fix, compiler warning fixes

### DIFF
--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -42,7 +42,7 @@ std::string de_wm() {
             // Start searching for \n occurrences.
             file.seekg(-1, std::ios_base::cur);
             int i = file.tellg();
-            for(i;i > 0; i--) {
+            for(;i > 0; i--) {
                 if(file.peek() == '\n') {
                     //Found
                     file.get();

--- a/src/music.cpp
+++ b/src/music.cpp
@@ -7,10 +7,8 @@ std::string music() {
     conn = mpd_connection_new("localhost", 6600, 1000);
 
     if (mpd_connection_get_error(conn) != MPD_ERROR_SUCCESS) {
-        fprintf(stderr, "Could not connect to mpd: %s\n", mpd_connection_get_error_message(conn));
-
-        mpd_connection_free(conn);
-        return NULL;
+    mpd_connection_free(conn);
+    return "N/A (could not connect to MPD)";
     }
     struct mpd_song *song;
     song = mpd_run_current_song(conn);

--- a/src/uptime.cpp
+++ b/src/uptime.cpp
@@ -32,5 +32,7 @@ std::string uptime() {
     } else if (uptime > 60) {
         int minutes = (uptime / 60) % 60;
         return std::to_string(minutes) + "m";
+    } else {
+	return "<1m";
     }
 }


### PR DESCRIPTION
- fix crash if libmpdclient is present but mpd is not running
- fix warning due to unneeded init parameter in a for loop
- fix warning in uptime.cpp due to not returning anything if system was up for <1m
